### PR TITLE
feat: 🎸 添加文件扩展名判断以支持无 Content-Type 请求头下的兼容问题

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -173,8 +173,33 @@ async function getResponse(event, client, requestId) {
   // Send the request to the client-side MSW.
   const reqHeaders = serializeHeaders(request.headers)
   const contentType = request.headers.get('Content-Type')
+  // 尝试获取文件名
+  const fileName = new URL(request.url).pathname.split('/').at(-1);
+  const suffix = fileName?.split('.').at(-1)?.toLowerCase();
+  const isBinary = suffix && [
+    // image
+    'jpg',
+    'jpeg',
+    'png',
+    'bmp',
+    'webp',
+    'ico',
+    'gif',
+    // audio & video
+    'mp3',
+    'aac',
+    'flac',
+    'wav',
+    'ape',
+    'ogg',
+    'mp4',
+    'avi',
+    'webm',
+  ].includes(suffix);
+
   let body
   if (
+    isBinary ||
     contentType &&
     (contentType.includes('image') ||
       contentType.includes('video') ||


### PR DESCRIPTION
- 列举了常见音视频图片文件类型
- 解决请求头丢失下的兼容问题（以防止作为一般文本文件处理导致的乱码问题）